### PR TITLE
Add notifications service to service list for primary site

### DIFF
--- a/service/auth.py
+++ b/service/auth.py
@@ -156,7 +156,6 @@ def get_tokens_on_tapipy_client():
     if t.jwt == 'dummy':
         # try to replace with a real token:
         t.jwt = None
-        t.access_token = None
         try:
             t.get_tokens()
             logger.info("tenants-api has just called get_tokens().")

--- a/service/auth.py
+++ b/service/auth.py
@@ -156,6 +156,7 @@ def get_tokens_on_tapipy_client():
     if t.jwt == 'dummy':
         # try to replace with a real token:
         t.jwt = None
+        t.access_token = None
         try:
             t.get_tokens()
             logger.info("tenants-api has just called get_tokens().")

--- a/service/models.py
+++ b/service/models.py
@@ -186,7 +186,7 @@ def ensure_primary_site_present():
                          base_url=base_url,
                          tenant_base_url_template=tenant_base_url_template,
                          site_admin_tenant_id='admin',
-                         services=['systems', 'apps', 'files', 'jobs', 'security', 'tokens', 'streams', 'authenticator', 'meta', 'actors', 'pgrest'])
+                         services=['systems', 'apps', 'files', 'jobs', 'notifications', 'security', 'tokens', 'streams', 'authenticator', 'meta', 'actors', 'pgrest'])
 
     except Exception as e:
         logger.error(f'Got exception trying to add the primary site. e: {e}')


### PR DESCRIPTION
Jobs now depends on Notifications service for full functionality.
So for a clean install the Notifications service should be in the list of services running in the primary site.